### PR TITLE
Feat/custom data

### DIFF
--- a/examples/custom-data/package.json
+++ b/examples/custom-data/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "custom-data",
+  "version": "1.0.0",
+  "description": "",
+  "license": "ISC",
+  "author": "",
+  "type": "commonjs",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "ciot-ts": "../../"
+  }
+}

--- a/examples/custom-data/src/protos/ciot/proto/v2/ble.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/ble.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/ble";

--- a/examples/custom-data/src/protos/ciot/proto/v2/ble_adv.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/ble_adv.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/ble_adv";

--- a/examples/custom-data/src/protos/ciot/proto/v2/ble_scn.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/ble_scn.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/ble_scn";

--- a/examples/custom-data/src/protos/ciot/proto/v2/ciot.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/ciot.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/ciot";

--- a/examples/custom-data/src/protos/ciot/proto/v2/dfu.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/dfu.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/dfu";

--- a/examples/custom-data/src/protos/ciot/proto/v2/errors.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/errors.ts
@@ -1,3 +1,1 @@
-import { Err } from "../../../../../../../src/protos/ciot/proto/v2/errors";
-
-export { Err };
+export * from "ciot-ts/src/protos/ciot/proto/v2/errors";

--- a/examples/custom-data/src/protos/ciot/proto/v2/gpio.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/gpio.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/gpio";

--- a/examples/custom-data/src/protos/ciot/proto/v2/http_client.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/http_client.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/http_client";

--- a/examples/custom-data/src/protos/ciot/proto/v2/http_server.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/http_server.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/http_server";

--- a/examples/custom-data/src/protos/ciot/proto/v2/iface copy.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/iface copy.ts
@@ -1,0 +1,1 @@
+export { IfaceInfo, GetData, Common } from "ciot-ts/src/protos/ciot/proto/v2/iface";

--- a/examples/custom-data/src/protos/ciot/proto/v2/iface.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/iface.ts
@@ -1,3 +1,1 @@
-import { IfaceInfo } from "../../../../../../../src/protos/ciot/proto/v2/iface";
-
-export { IfaceInfo };
+export * from "ciot-ts/src/protos/ciot/proto/v2/iface";

--- a/examples/custom-data/src/protos/ciot/proto/v2/logger.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/logger.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/logger";

--- a/examples/custom-data/src/protos/ciot/proto/v2/mbus_client.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/mbus_client.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/mbus_client";

--- a/examples/custom-data/src/protos/ciot/proto/v2/mbus_server.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/mbus_server.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/mbus_server";

--- a/examples/custom-data/src/protos/ciot/proto/v2/mqtt_client.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/mqtt_client.ts
@@ -1,0 +1,1 @@
+export { MqttClientData, MqttClientCfg, MqttClientStatus } from "ciot-ts/src/protos/ciot/proto/v2/mqtt_client";

--- a/examples/custom-data/src/protos/ciot/proto/v2/msg_data.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/msg_data.ts
@@ -1,3 +1,1 @@
-import { MsgData } from "../../../../../../../src/protos/ciot/proto/v2/msg_data";
-
-export { MsgData };
+export * from "ciot-ts/src/protos/ciot/proto/v2/msg_data";

--- a/examples/custom-data/src/protos/ciot/proto/v2/ntp.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/ntp.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/ntp";

--- a/examples/custom-data/src/protos/ciot/proto/v2/ota.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/ota.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/ota";

--- a/examples/custom-data/src/protos/ciot/proto/v2/storage.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/storage.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/storage";

--- a/examples/custom-data/src/protos/ciot/proto/v2/sys.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/sys.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/sys";

--- a/examples/custom-data/src/protos/ciot/proto/v2/tcp.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/tcp.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/tcp";

--- a/examples/custom-data/src/protos/ciot/proto/v2/uart.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/uart.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/uart";

--- a/examples/custom-data/src/protos/ciot/proto/v2/usb.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/usb.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/usb";

--- a/examples/custom-data/src/protos/ciot/proto/v2/wifi.ts
+++ b/examples/custom-data/src/protos/ciot/proto/v2/wifi.ts
@@ -1,0 +1,1 @@
+export * from "ciot-ts/src/protos/ciot/proto/v2/wifi";


### PR DESCRIPTION
This pull request sets up the `custom-data` example to use TypeScript modules from the main `ciot-ts` package, streamlining imports and improving maintainability. The changes replace relative imports with direct re-exports from `ciot-ts`, ensuring all protocol buffer modules are consistently sourced from the package.

Project setup:

* Added a new `package.json` file for the `custom-data` example, specifying dependencies and project metadata.

Module import refactoring:

* Updated all files in `examples/custom-data/src/protos/ciot/proto/v2/` to re-export modules directly from `ciot-ts` instead of using deep relative paths, simplifying and standardizing imports for protocol buffer modules such as `ble`, `ble_adv`, `ble_scn`, `ciot`, `dfu`, `errors`, `gpio`, `http_client`, `http_server`, `iface`, `logger`, `mbus_client`, `mbus_server`, `mqtt_client`, `msg_data`, `ntp`, `ota`, and `storage`. [[1]](diffhunk://#diff-c7091b4d1a00edf1380212651fe5eece939eba6f521cf5ba969c6c7530597a51R1) [[2]](diffhunk://#diff-4ab6521c97ba3041f216d6aa0b3b7b394135a6ebf8b728440a8796498f907ea7R1) [[3]](diffhunk://#diff-f3dd01e884b3ec23b6f8d26f425826099a071025d34c09c72d16f94ff86fe261R1) [[4]](diffhunk://#diff-6283a6c1f4aa68abba76e05ecad82efde651c4d2dda67dd8845c8f509f037dc7R1) [[5]](diffhunk://#diff-8ab565574172c1088f478489c13f0870647e5d01a5aef6ba4b831759fca96bc3R1) [[6]](diffhunk://#diff-8352b461ed64d2e5ac6d6aef8415a1a36c83af5e46d0f6318415fe79d5d73203L1-R1) [[7]](diffhunk://#diff-89901d0161381e6e5717f56aab92cb1211e9bb8ace2624480b34143cf9e6ebb7R1) [[8]](diffhunk://#diff-884996d346a8aa255b10310f5f352b618179d4c00fe5846938ea91288dcd60e5R1) [[9]](diffhunk://#diff-72fbe1d5cd79ae92588fef0432302ee5eee35ae139ac7bdff7fe06d161e513d0R1) [[10]](diffhunk://#diff-8af5514845183a077d31d892f56fbec9d34705ea6708bb573ec96d22067378c0L1-R1) [[11]](diffhunk://#diff-ba565dbec476b86af243c4702e3b2e65ff9d33aee8d748ae636adb3641f4f7d8R1) [[12]](diffhunk://#diff-042723dbe5b9fd4b767f48d126b394c8359c1a6fa63a280b2d5207a550c374bdR1) [[13]](diffhunk://#diff-77b2ab3ff6a7a1591daee176876ee0c266fc41cd0561c696cfbb6a1cb3609aa2R1) [[14]](diffhunk://#diff-669bd4e219e4813bf2a9c1b3dc5de7094b5cede017aecd12ebf2664e5c86fd4eR1) [[15]](diffhunk://#diff-aa40377996f60f9e42f1feac2581e76b72380952ba89d577c163768e187d1f76L1-R1) [[16]](diffhunk://#diff-5590583cd9b1f50c8247f607c4e266d4fcfbfb4e7fe1c088b49e6bf8947a5941R1) [[17]](diffhunk://#diff-7e514bcfdfc2a48f0317b77527af98d9b299d5fb993dc50e5b864296293e74a5R1) [[18]](diffhunk://#diff-4368a50f869055a80de413f949857a21c0ecc8c5d9e6a32be1d52cd336b6f272R1) [[19]](diffhunk://#diff-0b17bcfb3d09bafed27da5fd256162c926a1da3f0b8fdeb5614b12265ad30332R1)

These updates will make it easier to maintain and update protocol buffer definitions in the future, as all modules now reference the canonical source in the main package.